### PR TITLE
#25 / DE-7685: Fix Dockerfile base image source

### DIFF
--- a/kafka-iceberg/apache-flink/hms-standalone-s3/Dockerfile
+++ b/kafka-iceberg/apache-flink/hms-standalone-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM hms-standalone
+FROM ghcr.io/criccomini/hive-metastore-standalone:0.3.1
 
 RUN apt-get update && apt-get install -y curl rlwrap vim
 


### PR DESCRIPTION
Fixed Docker image source.

Tested: 

```
# Confirm no local images
❯ docker images --all
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE

# Bring up stack
❯ docker compose up -d
[…]
❯ docker compose ps
NAME                         IMAGE                               COMMAND                  SERVICE          CREATED          STATUS         PORTS
apache-flink-taskmanager-1   apache-flink-taskmanager            "/docker-entrypoint.…"   taskmanager      10 seconds ago   Up 9 seconds   6123/tcp, 8081/tcp
apache-flink-taskmanager-2   apache-flink-taskmanager            "/docker-entrypoint.…"   taskmanager      10 seconds ago   Up 9 seconds   6123/tcp, 8081/tcp
broker                       confluentinc/cp-kafka:7.5.1         "/etc/confluent/dock…"   kafka            10 seconds ago   Up 9 seconds   0.0.0.0:9092->9092/tcp, :::9092->9092/tcp
duckdb                       davidgasquez/duckdb                 "tail -f /dev/null"      duckdb           10 seconds ago   Up 9 seconds
hms                          apache-flink-hive-metastore         "./run.sh"               hive-metastore   10 seconds ago   Up 9 seconds   0.0.0.0:9083->9083/tcp, :::9083->9083/tcp
jobmanager                   apache-flink-jobmanager             "/docker-entrypoint.…"   jobmanager       10 seconds ago   Up 9 seconds   6123/tcp, 0.0.0.0:8081->8081/tcp, :::8081->8081/tcp
kcat                         edenhill/kcat:1.7.1                 "tail -f /dev/null"      kcat             10 seconds ago   Up 9 seconds
mc                           minio/mc                            "/bin/sh -c ' until …"   mc               10 seconds ago   Up 9 seconds
minio                        minio/minio                         "/usr/bin/docker-ent…"   minio            10 seconds ago   Up 9 seconds   0.0.0.0:9000-9001->9000-9001/tcp, :::9000-9001->9000-9001/tcp
pyiceberg                    python:3.12-bookworm                "/bin/sh -c ' pip in…"   pyiceberg        10 seconds ago   Up 9 seconds
shadowtraffic                shadowtraffic/shadowtraffic:0.6.0   "java -jar /home/sha…"   shadowtraffic    10 seconds ago   Up 9 seconds
zookeeper                    confluentinc/cp-zookeeper:7.5.1     "/etc/confluent/dock…"   zookeeper        10 seconds ago   Up 9 seconds   2181/tcp, 2888/tcp, 3888/tcp
```

Ran through https://github.com/decodableco/examples/blob/main/kafka-iceberg/apache-flink/ksl-demo.adoc successfully

![CleanShot 2024-09-24 at 10 05 10](https://github.com/user-attachments/assets/3d70997c-25a2-4777-b196-d30ed544ee31)


```sql
⚫◗ SELECT count(*), strftime(to_timestamp(max(create_ts)/1000),'%Y-%m-%d %H:%M:%S') as max_ts,
     avg(cost), min(cost)
     FROM iceberg_scan('s3://warehouse/default_database.db/t_i_orders/metadata/00001-6f1fb481-4d2e-4547-b930-b679899d32be.metadata.json');
┌──────────────┬─────────────────────┬────────────────────┬─────────────┐
│ count_star() │       max_ts        │    avg("cost")     │ min("cost") │
│    int64     │       varchar       │       double       │    float    │
├──────────────┼─────────────────────┼────────────────────┼─────────────┤
│           67 │ 2024-09-24 09:05:12 │ 113.40406514637506 │   100.41236 │
└──────────────┴─────────────────────┴────────────────────┴─────────────┘
```